### PR TITLE
Modified Utils#config

### DIFF
--- a/command/utils.rb
+++ b/command/utils.rb
@@ -61,9 +61,11 @@ module Utils
       @config = {}
       config.lines.each do |line|
         m = line.strip.match(/(.+)\s+: (.+)/)
+        if $1&&$2
         k = $1
         v = eval($2)
         @config[k.strip] = v
+        end
       end
     end
     @config


### PR DESCRIPTION
If the regexp failed, the parsing would crash. Now it checks to make
sure that $1 and $2 both contain values before assigning them to the
@config hash. This improves RedPotion compatibility.
